### PR TITLE
Use first call argument for placeholder text

### DIFF
--- a/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
+++ b/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
@@ -222,17 +222,15 @@ public class JSTestBlockFoldingBuilder implements FoldingBuilder
       return callExpression.getText();
     }
 
-    JSLiteralExpression jsExpression = (JSLiteralExpression) firstCallArgument;
-
-    String stringValue = jsExpression.getStringValue();
+    String stringValue = ((JSLiteralExpression) firstCallArgument).getStringValue();
 
     if(stringValue != null) {
       return stringValue;
     }
 
-    String textValue = jsExpression.getText();
+    String textValue = firstCallArgument.getText();
 
-    return textValue.substring(1, jsExpression.getText().length() - 1);
+    return textValue.substring(1, textValue.length() - 1);
   }
 
   private int findOffsetOfLineForTextRange(@NotNull Document document, @NotNull TextRange range)

--- a/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
+++ b/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
@@ -216,17 +216,13 @@ public class JSTestBlockFoldingBuilder implements FoldingBuilder
    */
   private String buildPlaceholderText(@NotNull JSCallExpressionImpl callExpression)
   {
-    JSLiteralExpression jsExpression = (
-      Arrays.stream(callExpression.getArguments())
-            .filter(expression -> expression instanceof JSLiteralExpression)
-            .map(expression -> (JSLiteralExpression) expression)
-            .findFirst()
-            .orElse(null)
-    );
+    JSExpression firstCallArgument = callExpression.getArguments()[0];
 
-    if(jsExpression == null) {
+    if(!(firstCallArgument instanceof JSLiteralExpression)) {
       return callExpression.getText();
     }
+
+    JSLiteralExpression jsExpression = (JSLiteralExpression) firstCallArgument;
 
     String stringValue = jsExpression.getStringValue();
 

--- a/src/main/java/jones/foldtestblocks/RubyTestBlockFoldingBuilder.java
+++ b/src/main/java/jones/foldtestblocks/RubyTestBlockFoldingBuilder.java
@@ -97,17 +97,13 @@ public class RubyTestBlockFoldingBuilder implements FoldingBuilder
    */
   private String buildPlaceholderText(@NotNull RCall rCall)
   {
-    RLiteral rLiteral = (
-      Arrays.stream(rCall.getCallArguments().getElements().toArray(new RPsiElement[0]))
-            .filter(expression -> expression instanceof RLiteral)
-            .map(element -> (RLiteral) element)
-            .findFirst()
-            .orElse(null)
-    );
+    RPsiElement firstCallArgument = rCall.getArguments().get(0);
 
-    if(rLiteral == null) {
+    if(!(firstCallArgument instanceof RLiteral)) {
       return rCall.getText();
     }
+
+    RLiteral rLiteral = (RLiteral) firstCallArgument;
 
     String stringValue = rLiteral.getContent();
 

--- a/src/main/java/jones/foldtestblocks/RubyTestBlockFoldingBuilder.java
+++ b/src/main/java/jones/foldtestblocks/RubyTestBlockFoldingBuilder.java
@@ -99,21 +99,11 @@ public class RubyTestBlockFoldingBuilder implements FoldingBuilder
   {
     RPsiElement firstCallArgument = rCall.getArguments().get(0);
 
-    if(!(firstCallArgument instanceof RLiteral)) {
-      return rCall.getText();
+    if(firstCallArgument instanceof RLiteral) {
+      return ((RLiteral) firstCallArgument).getContent();
     }
 
-    RLiteral rLiteral = (RLiteral) firstCallArgument;
-
-    String stringValue = rLiteral.getContent();
-
-    if(stringValue != null) {
-      return stringValue;
-    }
-
-    String textValue = rLiteral.getText();
-
-    return textValue.substring(1, rLiteral.getText().length() - 1);
+    return rCall.getText();
   }
 
   @Nullable


### PR DESCRIPTION
The first argument of a test block is expected to be its message/description.

Instead of checking every argument, we can just check the first one.