### PR TITLE
Js blocks not folding without newlines

### DIFF
--- a/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
+++ b/src/main/java/jones/foldtestblocks/JSTestBlockFoldingBuilder.java
@@ -200,6 +200,10 @@ public class JSTestBlockFoldingBuilder implements FoldingBuilder
     // offset of the start of the line before the start of the next test block
     int offsetOfLineBeforeNextTestBlock = document.getLineStartOffset(nextTestBlockStartLineNum - 1);
 
+    if(range.getEndOffset() > offsetOfLineBeforeNextTestBlock) {
+      offsetOfLineBeforeNextTestBlock = range.getEndOffset();
+    }
+
     return new TextRange(
       range.getStartOffset(),
       offsetOfLineBeforeNextTestBlock

--- a/testData/js/FoldingTestData.ts
+++ b/testData/js/FoldingTestData.ts
@@ -1,6 +1,6 @@
 // @formatter:off
 describe('root', () => <fold text='{...}'>{
-  <fold text='when something happens'>describe('when something happens', () => <fold text='{...}'>{
+  <fold text='single quotes'>describe('single quotes', () => <fold text='{...}'>{
     <fold text='is true 1'>it('is true 1', () => <fold text='{...}'>{
       expect(true).toBe(true);
     }</fold>);</fold>
@@ -10,5 +10,64 @@ describe('root', () => <fold text='{...}'>{
     <fold text='is true 3'>it('is true 3', () => <fold text='{...}'>{
       expect(true).toBe(true);
     }</fold>);</fold>
+  }</fold>);</fold>
+  <fold text='double quotes'>describe("double quotes", () => <fold text='{...}'>{
+    <fold text='is true 1'>it("is true 1", () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true 2'>it("is true 2", () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true 3'>it("is true 3", () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+  }</fold>);</fold>
+  <fold text='simple template literal'>describe(`simple template literal`, () => <fold text='{...}'>{
+    <fold text='is true 1'>it(`is true 1`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true 2'>it(`is true 2`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true 3'>it(`is true 3`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+  }</fold>);</fold>
+  <fold text='complex template ${`literal`}'>describe(`complex template ${`literal`}`, () => <fold text='{...}'>{
+    <fold text='is true ${`1`}'>it(`is true ${`1`}`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true ${"2"}'>it(`is true ${"2"}`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is ${true} 3'>it(`is ${true} 3`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+  }</fold>);</fold>
+  <fold text='mixed strings'>describe('mixed strings', () => <fold text='{...}'>{
+    <fold text='is true 1'>it('is true 1', () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is true 2'>it("is true 2", () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+    <fold text='is ${true} 3'>it(`is ${true} 3`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+  }</fold>);</fold>
+  <fold text='new lines'>describe('new lines', () => <fold text='{...}'>{
+    <fold text='is true 1'>it('is true 1', () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);
+</fold>
+    <fold text='is true 2'>it("is true 2", () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);
+
+</fold>
+    <fold text='is ${true} 3'>it(`is ${true} 3`, () => <fold text='{...}'>{
+      expect(true).toBe(true);
+    }</fold>);</fold>
+
   }</fold>);</fold>
 }</fold>);

--- a/testData/js/original.ts
+++ b/testData/js/original.ts
@@ -1,5 +1,6 @@
+// @formatter:off
 describe('root', () => {
-  describe('when something happens', () => {
+  describe('single quotes', () => {
     it('is true 1', () => {
       expect(true).toBe(true);
     });
@@ -9,5 +10,64 @@ describe('root', () => {
     it('is true 3', () => {
       expect(true).toBe(true);
     });
+  });
+  describe("double quotes", () => {
+    it("is true 1", () => {
+      expect(true).toBe(true);
+    });
+    it("is true 2", () => {
+      expect(true).toBe(true);
+    });
+    it("is true 3", () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe(`simple template literal`, () => {
+    it(`is true 1`, () => {
+      expect(true).toBe(true);
+    });
+    it(`is true 2`, () => {
+      expect(true).toBe(true);
+    });
+    it(`is true 3`, () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe(`complex template ${'literal'}`, () => {
+    it(`is true ${'1'}`, () => {
+      expect(true).toBe(true);
+    });
+    it(`is true ${"2"}`, () => {
+      expect(true).toBe(true);
+    });
+    it(`is ${true} 3`, () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe('mixed strings', () => {
+    it('is true 1', () => {
+      expect(true).toBe(true);
+    });
+    it("is true 2", () => {
+      expect(true).toBe(true);
+    });
+    it(`is ${true} 3`, () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe('new lines', () => {
+    it('is true 1', () => {
+      expect(true).toBe(true);
+    });
+
+    it("is true 2", () => {
+      expect(true).toBe(true);
+    });
+
+
+    it(`is ${true} 3`, () => {
+      expect(true).toBe(true);
+    });
+
   });
 });


### PR DESCRIPTION
Minor fix for bug w/ new lines, where we'd not fold if there wasn't a newline between two text blocks.